### PR TITLE
Fixed EKS terraform module to 20.20.0

### DIFF
--- a/src/config/system.ts
+++ b/src/config/system.ts
@@ -133,7 +133,7 @@ class SystemConfig {
             "github_provider_version": "~> 6.0",
             "aws_provider_version": "5.57.0",
             "aws_vpc_module_version": "5.5.1",
-            "aws_eks_module_version": "~> 20.0",
+            "aws_eks_module_version": "20.20.0",
             "aws_eks_cluster_version": "1.30",
             "aws_load_balancer_controller_version": "1.8.0",
             "aws_az_count": "2",


### PR DESCRIPTION
This PR changes the following:

- Changed EKS terraform module version to 20.20.0. This will solve terraform init version dependency on the latest version all the times.
- Change to update the AWS provider version is already covered in [PR-37](https://github.com/calfus-open-source/magikube/pull/37).